### PR TITLE
adding more signature replay considerations

### DIFF
--- a/data/39.md
+++ b/data/39.md
@@ -4,7 +4,7 @@
 The implementation of a cryptographic signature system in Ethereum contracts often assume that the signature is unique, but signatures can be altered without the possession of the private key and still be valid. The EVM specification defines several so-called ‘precompiled’ contracts one of them being `ecrecover` which executes the elliptic curve public key recovery. A malicious user can slightly modify the three values *v*, *r,* and *s* to create other valid signatures. A system that performs signature verification on the contract level might be susceptible to attacks if the signature is part of the signed message hash. Valid signatures could be created by a malicious user to replay previously signed messages.
 
 ### Remediation:
-A signature should never be included in a signed message hash to check if previous messages have been processed by the contract.
+A signature should never be included in a signed message hash to check if previous messages have been processed by the contract. Consider using OpenZeppelin’s [https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/ECDSA.sol](ECDSA.sol) library to help prevent signature malleability attacks, rather than calling ecrecover() directly.
 
 ### References:
 [https://swcregistry.io/docs/SWC-117](https://swcregistry.io/docs/SWC-117)

--- a/data/39.md
+++ b/data/39.md
@@ -4,7 +4,7 @@
 The implementation of a cryptographic signature system in Ethereum contracts often assume that the signature is unique, but signatures can be altered without the possession of the private key and still be valid. The EVM specification defines several so-called ‘precompiled’ contracts one of them being `ecrecover` which executes the elliptic curve public key recovery. A malicious user can slightly modify the three values *v*, *r,* and *s* to create other valid signatures. A system that performs signature verification on the contract level might be susceptible to attacks if the signature is part of the signed message hash. Valid signatures could be created by a malicious user to replay previously signed messages.
 
 ### Remediation:
-A signature should never be included in a signed message hash to check if previous messages have been processed by the contract. Consider using OpenZeppelin’s [https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/ECDSA.sol](ECDSA.sol) library to help prevent signature malleability attacks, rather than calling ecrecover() directly.
+A signature should never be included in a signed message hash to check if previous messages have been processed by the contract. Consider using OpenZeppelin’s [ECDSA.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/ECDSA.sol) library to help prevent signature malleability attacks, rather than calling ecrecover() directly.
 
 ### References:
 [https://swcregistry.io/docs/SWC-117](https://swcregistry.io/docs/SWC-117)

--- a/data/40.md
+++ b/data/40.md
@@ -8,6 +8,12 @@ In order to protect against signature replay attacks consider the following reco
 
 - Store every message hash that has been processed by the smart contract. When new messages are received check against the already existing ones and only proceed with the business logic if it's a new message hash.
 - Include the address of the contract that processes the message. This ensures that the message can only be used in a single contract.
+- Include a nonce in the signature. Callers must sign their message using the current nonce, contracts must check the signed message against the current nonce, store the current nonce as used and increment it.
+- Include the chain_id in the signature to prevent cross-chain replay attacks; contracts and addresses often have the same address across multiple chains, signatures which don't incorporate chain_id can be replayed from one chain onto other chains.
+- Include all relevant parameters in the signature; a signature the enables the spending of tokens should include the exact amount as part of the signature.
+- Include an expiration timestamp, such that the signature will cease to be valid after a user-supplied deadline.
+- Signature implementions using ecrecover() directly must explicitly check the return of ecrecover() which returns 0 if the signature is invalid, and be especially careful when comparing the return of ecrecover() to a user-supplied value, as an attacker can supply 0 therefore passing such a check with an invalid signature.
 
 ### References:
 [https://swcregistry.io/docs/SWC-121](https://swcregistry.io/docs/SWC-121)
+[https://dacian.me/signature-replay-attacks](https://dacian.me/signature-replay-attacks)

--- a/data/40.md
+++ b/data/40.md
@@ -16,4 +16,5 @@ In order to protect against signature replay attacks consider the following reco
 
 ### References:
 [https://swcregistry.io/docs/SWC-121](https://swcregistry.io/docs/SWC-121)
+
 [https://dacian.me/signature-replay-attacks](https://dacian.me/signature-replay-attacks)


### PR DESCRIPTION
I've done a deep dive of all 145 H/M c4/sherlock audit findings with the word "signature" in them, adding the fruits of this deep dive to the signature replay/malleability sections.